### PR TITLE
Updated to reflect deprecation in React 0.12

### DIFF
--- a/react-treeview.jsx
+++ b/react-treeview.jsx
@@ -16,7 +16,7 @@
     propTypes: {
       collapsed: React.PropTypes.bool,
       defaultCollapsed: React.PropTypes.bool,
-      nodeLabel: React.PropTypes.renderable.isRequired
+      nodeLabel: React.PropTypes.node.isRequired
     },
 
     getInitialState: function() {


### PR DESCRIPTION
The change is detailed in [the changelog](https://facebook.github.io/react/blog/2014/10/28/react-v0.12.html) for React 0.12.
