### PR TITLE
add support for 0.14.0-rc1 now

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/chenglou/react-treeview",
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.12.0 || ^0.14.0-rc1"
   },
   "devDependencies": {
     "babel": "^5.6.14",


### PR DESCRIPTION
avoid 
```
npm ERR! peerinvalid The package react@0.14.0-beta3 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-treeview@0.4.0 wants react@>=0.12.0
```
error