### PR TITLE
Arrow symbol in CSS

### DIFF
--- a/react-treeview.css
+++ b/react-treeview.css
@@ -26,6 +26,10 @@
   user-select: none;
 }
 
+.tree-view_arrow:after {
+  content: '▾';
+}
+
 /* rotate the triangle to close it */
 .tree-view_arrow-collapsed {
   -webkit-transform: rotate(-90deg);

--- a/src/react-treeview.jsx
+++ b/src/react-treeview.jsx
@@ -38,9 +38,7 @@ const TreeView = React.createClass({
       <div
         {...rest}
         className={className + ' ' + arrowClassName}
-        onClick={this.handleClick}>
-        ▾
-      </div>;
+        onClick={this.handleClick}/>;
 
     return (
       <div className="tree-view">


### PR DESCRIPTION
Our treeview design requires a different symbol for the arrow. This change moves the symbol for the arrow into the CSS, where it can be easily overridden.