### PR TITLE
Issue 35: Don't pass defaultCollapsed prop to arrow div (Unknown prop)

### DIFF
--- a/src/react-treeview.jsx
+++ b/src/react-treeview.jsx
@@ -27,6 +27,7 @@ const TreeView = React.createClass({
       itemClassName = '',
       nodeLabel,
       children,
+      defaultCollapsed,
       ...rest,
     } = this.props;
 


### PR DESCRIPTION
With react 15.2.1 I Unknown prop warning for defaultCollapsed on arrow div

Remove this from ...rest to clear warning

