### PR TITLE
Exclude defaultCollapsed from props passed to div

### DIFF
--- a/src/react-treeview.jsx
+++ b/src/react-treeview.jsx
@@ -23,6 +23,7 @@ const TreeView = React.createClass({
   render() {
     const {
       collapsed = this.state.collapsed,
+      defaultCollapsed,
       className = '',
       itemClassName = '',
       nodeLabel,


### PR DESCRIPTION
React now complains about unknown props. 
```
warning.js:36 Warning: Unknown prop `defaultCollapsed` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
```

This PR adds defaultCollapsed in props assignment so it's excluded from `rest...`