### PR TITLE
Fix warning message shown in browser console to avoid using depreciated class from react version >=15.5.0

### DIFF
--- a/demos/controlled.js
+++ b/demos/controlled.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TreeView from '../src/react-treeview';
+import CreateReactClass from 'create-react-class';
 
 // This example data format is totally arbitrary. No data massaging is
 // required and you use regular js in `render` to iterate through and
@@ -14,7 +15,7 @@ const dataSource = [
 // (http://facebook.github.io/react/docs/forms.html#controlled-components), has
 // many benefits. Among others, you can expand/collapse everything (i.e. easily
 // trigger those somewhere else).
-const Lists = React.createClass({
+const Lists = CreateReactClass({
   getInitialState() {
     return {
       collapsedBookkeeping: dataSource.map(() => false),

--- a/demos/uncontrolled.js
+++ b/demos/uncontrolled.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TreeView from '../src/react-treeview';
+import CreateReactClass from 'create-react-class';
 
 // This example data format is totally arbitrary. No data massaging is
 // required and you use regular js in `render` to iterate through and
@@ -25,7 +26,7 @@ const dataSource = [
 // For the sake of simplicity, we're gonna use `defaultCollapsed`. Usually, a
 // [controlled component](http://facebook.github.io/react/docs/forms.html#controlled-components)
 // is preferred.
-const CompanyPeople = React.createClass({
+const CompanyPeople = CreateReactClass({
   render() {
     return (
       <div>

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "react-hot-loader": "^1.3.0",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.10.1"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.6"
   }
 }

--- a/src/react-treeview.jsx
+++ b/src/react-treeview.jsx
@@ -1,6 +1,8 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import CreateReactClass from 'create-react-class';
 
-const TreeView = React.createClass({
+const TreeView = CreateReactClass({
   propTypes: {
     collapsed: PropTypes.bool,
     defaultCollapsed: PropTypes.bool,


### PR DESCRIPTION
- Added prop-types and create-react class package module via npm;
- Fix existing code to use prop-types and create-react-class library instead