### PR TITLE
Allow to add custom classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The component accepts [these props](https://github.com/chenglou/react-treeview/b
 - `collapsed`: whether the node is collapsed or not.
 - `defaultCollapsed`: the [uncontrolled](http://facebook.github.io/react/docs/forms.html#uncontrolled-components) equivalent to `collapsed`.
 - `nodeLabel`: the component or string (or anything renderable) that's displayed beside the TreeView arrow.
-- `itemClassName`: the class name of the tree view item div.
+- `itemClassName`: the class name of the `.tree-view_item` div.
+- `treeViewClassName`: the class name of the `.tree-view` div.
+- `childrenClassName`: the class name of the `.tree-view_children` item div.
 
 TreeViews can be naturally nested.
 

--- a/src/react-treeview.jsx
+++ b/src/react-treeview.jsx
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 
 const TreeView = React.createClass({
   propTypes: {
@@ -7,14 +7,16 @@ const TreeView = React.createClass({
     nodeLabel: PropTypes.node.isRequired,
     className: PropTypes.string,
     itemClassName: PropTypes.string,
+    childrenClassName: PropTypes.string,
+    treeViewClassName: PropTypes.string,
   },
 
   getInitialState() {
-    return {collapsed: this.props.defaultCollapsed};
+    return { collapsed: this.props.defaultCollapsed };
   },
 
   handleClick(...args) {
-    this.setState({collapsed: !this.state.collapsed});
+    this.setState({ collapsed: !this.state.collapsed });
     if (this.props.onClick) {
       this.props.onClick(...args);
     }
@@ -25,10 +27,12 @@ const TreeView = React.createClass({
       collapsed = this.state.collapsed,
       className = '',
       itemClassName = '',
+      treeViewClassName = '',
+      childrenClassName = '',
       nodeLabel,
       children,
       defaultCollapsed,
-      ...rest,
+      ...rest
     } = this.props;
 
     let arrowClassName = 'tree-view_arrow';
@@ -38,19 +42,21 @@ const TreeView = React.createClass({
       containerClassName += ' tree-view_children-collapsed';
     }
 
-    const arrow =
+    const arrow = (
       <div
         {...rest}
         className={className + ' ' + arrowClassName}
-        onClick={this.handleClick}/>;
+        onClick={this.handleClick}
+      />
+    );
 
     return (
-      <div className="tree-view">
+      <div className={'tree-view ' + treeViewClassName}>
         <div className={'tree-view_item ' + itemClassName}>
           {arrow}
           {nodeLabel}
         </div>
-        <div className={containerClassName}>
+        <div className={containerClassName + ' ' + childrenClassName}>
           {collapsed ? null : children}
         </div>
       </div>


### PR DESCRIPTION
Adding custom classes for `<div />` other than`tree-view_item` is useful to customize the CSS.